### PR TITLE
Update generation.py

### DIFF
--- a/model/generation.py
+++ b/model/generation.py
@@ -147,7 +147,7 @@ def compute_ppl(model, tokenizer, stride, max_position_embeddings, prompting, ta
         print(data)
         if data == "wikitext":
             names = []    
-            with open("./model/wikitext-2-raw-v1_" + split + ".txt", 'r') as fp:
+            with open("./model/wikitext-2-raw-v1_" + split + ".txt", 'r', encoding='utf-8') as fp:
                 for line in fp:
                     # remove linebreak from a current name
                     # linebreak is the last character of each line
@@ -155,7 +155,9 @@ def compute_ppl(model, tokenizer, stride, max_position_embeddings, prompting, ta
                     # add current item to the list
                     names.append(x)
         else:
-            names = json.load(open("./prompts/" + str(prompting) + "/" + prompting + "_" + split + "_prompts.json", "r"))[targeted_bias][data]
+            # names = json.load(open("./prompts/" + str(prompting) + "/" + prompting + "_" + split + "_prompts.json", "r"))[targeted_bias][data]
+            with open("./prompts/" + str(prompting) + "/" + prompting + "_" + split + "_prompts.json", 'r', encoding='utf-8') as fp:
+              names = json.load(fp)[targeted_bias][data]
 
         encodings = tokenizer("".join(names) , return_tensors="pt")
         seq_len = encodings.input_ids.size(1)


### PR DESCRIPTION
The original code gave me this error:

```prompts_mistralai_Mistral-7B-Instruct-v0.2_4
  0%|          | 0/65 [00:00<?, ?it/s]
prompts_mistralai_Mistral-7B-Instruct-v0.2_5
  0%|          | 0/64 [00:00<?, ?it/s]
wikitext
Traceback (most recent call last):
  File "/mnt/beegfs/labs/srajwal/bias_models_bias_thoughts/CAIRO_github/CAIRO-main/main.py", line 165, in <module>
    ppl = compute_ppl(model,tokenizer, args.stride, args.max_length, args.prompting, args.targeted_bias, split)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/beegfs/labs/srajwal/bias_models_bias_thoughts/CAIRO_github/CAIRO-main/model/generation.py", line 151, in compute_ppl
    for line in fp:
  File "/opt/modules/Python/3.11.5/lib/python3.11/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 1770: ordinal not in range(128)```